### PR TITLE
Feat: Fetch news from multiple sources and improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This project is a simple, dynamically updating website that displays the latest 
 
 ## Features
 
-*   **Dynamic News Feed:** Fetches and displays the latest news articles from RSS feeds. Currently configured to pull from MarkTechPost.
+*   **Multi-Source Dynamic News Feed:** Fetches and displays the latest news articles from a variety of RSS/Atom feeds, including MarkTechPost, TechCrunch (AI and General), and Hacker News (AI Search and Frontpage).
+*   **News Aggregation & Sorting:** News items from all configured sources are aggregated, sorted by publication date (most recent first), and then displayed.
 *   **Professional Design:** Styled with a clean, modern, dark-themed interface suitable for a tech news site.
 *   **Responsive (Basic):** The layout is designed to be usable across different screen sizes.
 
@@ -12,16 +13,30 @@ This project is a simple, dynamically updating website that displays the latest 
 
 *   `index.html`: The main HTML file containing the structure of the website.
 *   `style.css`: Contains all the CSS rules for styling the website.
-*   `app.js`: Handles the fetching, parsing, and display of news articles from RSS feeds.
+*   `app.js`: Handles the fetching, parsing, aggregation, sorting, and display of news articles.
 
 ## How it Works
 
-The website uses client-side JavaScript to:
-1.  Fetch an RSS feed from a news source (MarkTechPost by default).
-2.  A CORS proxy (`api.allorigins.win`) is used to bypass browser cross-origin restrictions when fetching the feed if a direct fetch fails.
-3.  The fetched XML data is parsed using `DOMParser`.
-4.  Relevant information (title, link, publication date, description) is extracted from the news items.
-5.  These items are then dynamically inserted into the main content area of the page.
+The website uses client-side JavaScript (`app.js`) to:
+1.  Manage an array of predefined news source objects, each containing a name and a feed URL.
+2.  Concurrently fetch all news feeds using `Promise.all` for efficiency.
+3.  A CORS proxy (`api.allorigins.win`) is used to bypass browser cross-origin restrictions when fetching feeds if a direct fetch fails.
+4.  The fetched data is parsed using `DOMParser`. The script supports both RSS (e.g., `<item>`, `<pubDate>`) and Atom (e.g., `<entry>`, `<published>`) feed formats.
+5.  Relevant information (title, link, publication date, description, source name) is extracted from the news items.
+6.  All fetched items are aggregated into a single list, sorted by publication date (most recent first).
+7.  A limited number of the latest items are then dynamically inserted into the main content area of the page.
+
+## Configured News Sources
+
+The following news sources are currently configured in `app.js`:
+
+*   **MarkTechPost:** General AI and tech news.
+*   **TechCrunch AI:** Focused on Artificial Intelligence news from TechCrunch.
+*   **TechCrunch (General):** General technology news from TechCrunch.
+*   **Hacker News (AI Search):** Articles matching "AI" from Hacker News (via `hnrss.org`).
+*   **Hacker News (Frontpage):** Top stories from Hacker News's frontpage (official RSS feed).
+
+The script is designed to pull from these specific feeds. The variety helps ensure a good mix of content.
 
 ## Running
 
@@ -29,17 +44,18 @@ Simply open the `index.html` file in a web browser. An internet connection is re
 
 ## Customization
 
-### Changing the RSS Feed
+### Changing or Adding News Sources
 
-To change the news source, you can modify the `feedUrl` variable at the beginning of the `app.js` file:
+To change or add news sources, you can modify the `newsSources` array at the beginning of the `app.js` file:
 
 ```javascript
 // app.js
-async function fetchNews() {
-  const newsContent = document.getElementById('news-content');
-  const feedUrl = 'YOUR_NEW_RSS_FEED_URL_HERE'; // <--- Change this line
-  const corsProxy = 'https://api.allorigins.win/raw?url=';
-  // ... rest of the function
-}
+const newsSources = [
+  { name: "MarkTechPost", url: "http://marktechpost.com/feed/" },
+  { name: "TechCrunch AI", url: "https://techcrunch.com/category/artificial-intelligence/feed/" },
+  // Add or modify sources here, for example:
+  // { name: "Your Custom Source", url: "YOUR_RSS_OR_ATOM_FEED_URL_HERE" },
+];
+// ... rest of the script
 ```
-Replace `'YOUR_NEW_RSS_FEED_URL_HERE'` with the URL of the desired RSS feed.
+Replace or add objects with `name` (for display) and `url` (the feed's web address). Ensure the URL points to a valid RSS or Atom feed.

--- a/app.js
+++ b/app.js
@@ -1,102 +1,231 @@
-async function fetchNews() {
-  const newsContent = document.getElementById('news-content');
-  const feedUrl = 'http://marktechpost.com/feed/';
-  const corsProxy = 'https://api.allorigins.win/raw?url=';
+const newsSources = [
+  { name: "MarkTechPost", url: "http://marktechpost.com/feed/" },
+  { name: "TechCrunch AI", url: "https://techcrunch.com/category/artificial-intelligence/feed/" },
+  { name: "TechCrunch (General)", url: "https://techcrunch.com/feed/" },
+  { name: "Hacker News AI", url: "https://hnrss.org/search?q=AI" },
+  { name: "Hacker News (Frontpage)", url: "https://news.ycombinator.com/rss" }
+];
+
+const CORS_PROXY = 'https://api.allorigins.win/raw?url=';
+const MAX_DISPLAY_ITEMS = 15;
+
+async function fetchAndParseFeed(source) {
+  const { name, url } = source;
+  let currentFetchUrl = url;
+  let response;
+  let usedProxy = false;
+
+  console.log(`fetchAndParseFeed: Started for source: ${name} (${url})`);
 
   try {
-    let response;
+    // 1. Try direct fetch
+    console.log(`fetchAndParseFeed: [${name}] Attempting to fetch directly from: ${url}`);
     try {
-      response = await fetch(feedUrl);
+      response = await fetch(url);
+      console.log(`fetchAndParseFeed: [${name}] Direct fetch response status: ${response.status}, ok: ${response.ok}`);
+      if (!response.ok && response.status !== 0) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+       // Check for non-XML content type (e.g. TechCrunch sometimes returns HTML on direct errors)
+      const contentType = response.headers.get("content-type");
+      if (contentType && !contentType.includes("xml") && !contentType.includes("rss")) {
+        console.warn(`fetchAndParseFeed: [${name}] Direct fetch returned non-XML content-type: ${contentType}. This might be an error page.`);
+        throw new Error(`Direct fetch returned non-XML content-type: ${contentType}`);
+      }
     } catch (error) {
-      // If direct fetch fails, try with CORS proxy
-      if (error instanceof TypeError) { // CORS errors are often TypeErrors
-        console.warn('Direct fetch failed, trying with CORS proxy.');
-        response = await fetch(corsProxy + feedUrl);
-      } else {
-        throw error; // Re-throw other errors
+      console.warn(`fetchAndParseFeed: [${name}] Direct fetch failed. Error: ${error.message}. Attempting with CORS proxy.`);
+      usedProxy = true;
+      currentFetchUrl = CORS_PROXY + encodeURIComponent(url); // Ensure URL is encoded for proxy
+      console.log(`fetchAndParseFeed: [${name}] Attempting to fetch with proxy: ${currentFetchUrl}`);
+      try {
+        response = await fetch(currentFetchUrl);
+        console.log(`fetchAndParseFeed: [${name}] Proxy fetch response status: ${response.status}, ok: ${response.ok}`);
+        if (!response.ok) {
+          throw new Error(`HTTP error with proxy! status: ${response.status}`);
+        }
+      } catch (proxyError) {
+        console.error(`fetchAndParseFeed: [${name}] Proxy fetch also failed. Error: ${proxyError.message}`);
+        throw new Error(`Failed to fetch from ${name} (direct and proxy). Proxy error: ${proxyError.message}`);
       }
     }
 
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
+    console.log(`fetchAndParseFeed: [${name}] Fetch successful. Reading text data...`);
+    const textData = await response.text();
+    // console.log(`fetchAndParseFeed: [${name}] Fetched text data snippet (first 300 chars): ${textData.substring(0, 300)}`);
+
+    console.log(`fetchAndParseFeed: [${name}] Parsing XML data...`);
+    const parser = new DOMParser();
+    let xmlDoc;
+    try {
+      xmlDoc = parser.parseFromString(textData, "text/xml");
+    } catch (parseError) {
+      console.error(`fetchAndParseFeed: [${name}] DOMParser.parseFromString failed. Error: ${parseError.message}`);
+      throw new Error(`Error parsing news feed from ${name} (parser.parseFromString).`);
     }
 
-    const textData = await response.text();
-    const parser = new DOMParser();
-    const xmlDoc = parser.parseFromString(textData, "text/xml");
-
-    // Check for parsing errors
     const parsingError = xmlDoc.querySelector("parsererror");
     if (parsingError) {
-        console.error("Error parsing XML:", parsingError);
-        // Attempt to fetch with CORS proxy if direct fetch was used and parsing failed
-        if (!response.url.startsWith(corsProxy.split('?')[0])) { // Check if proxy was already used
-             console.warn('Direct fetch parsing failed, trying with CORS proxy.');
-             response = await fetch(corsProxy + feedUrl);
-             if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status} (with proxy)`);
-             }
-             const proxiedTextData = await response.text();
-             const proxiedXmlDoc = parser.parseFromString(proxiedTextData, "text/xml");
-             const proxiedParsingError = proxiedXmlDoc.querySelector("parsererror");
-             if (proxiedParsingError) {
-                console.error("Error parsing XML with proxy:", proxiedParsingError);
-                throw new Error('Failed to parse RSS feed even with proxy.');
-             }
-             // If proxy worked, use its doc
-             xmlDoc = proxiedXmlDoc;
-        } else {
-            throw new Error('Failed to parse RSS feed.');
+      console.error(`fetchAndParseFeed: [${name}] Error parsing XML (parsererror tag found):`, parsingError.textContent);
+      if (!usedProxy && !response.url.startsWith(CORS_PROXY.split('?')[0])) {
+        console.warn(`fetchAndParseFeed: [${name}] Parsing error with direct fetch data. Trying fetch with CORS proxy for potentially cleaner data.`);
+        usedProxy = true;
+        currentFetchUrl = CORS_PROXY + encodeURIComponent(url);
+        console.log(`fetchAndParseFeed: [${name}] Re-fetching with proxy for parsing: ${currentFetchUrl}`);
+        try {
+          response = await fetch(currentFetchUrl);
+          console.log(`fetchAndParseFeed: [${name}] Proxy re-fetch response status: ${response.status}, ok: ${response.ok}`);
+          if (!response.ok) {
+            throw new Error(`HTTP error with proxy re-fetch! status: ${response.status}`);
+          }
+          const proxiedTextData = await response.text();
+          xmlDoc = parser.parseFromString(proxiedTextData, "text/xml");
+          const proxiedParsingError = xmlDoc.querySelector("parsererror");
+          if (proxiedParsingError) {
+            console.error(`fetchAndParseFeed: [${name}] Error parsing XML with proxy data as well (parsererror tag found):`, proxiedParsingError.textContent);
+            throw new Error(`Failed to parse RSS feed from ${name} even with proxy (parsererror tag found).`);
+          }
+          console.log(`fetchAndParseFeed: [${name}] Successfully parsed XML data with proxy re-fetch.`);
+        } catch (proxyRefetchError) {
+          console.error(`fetchAndParseFeed: [${name}] Proxy re-fetch or parsing failed. Error: ${proxyRefetchError.message}`);
+          throw new Error(`Failed during proxy re-fetch for parsing from ${name}. Error: ${proxyRefetchError.message}`);
         }
+      } else {
+        throw new Error(`Failed to parse RSS feed from ${name} (parsererror tag found).`);
+      }
+    } else {
+      console.log(`fetchAndParseFeed: [${name}] Successfully parsed XML data.`);
     }
 
-
-    const items = Array.from(xmlDoc.querySelectorAll('item')).slice(0, 5); // Get first 5 items
+    const items = Array.from(xmlDoc.querySelectorAll('item, entry')); // 'entry' for Atom feeds
+    console.log(`fetchAndParseFeed: [${name}] Found ${items.length} news items in the feed.`);
 
     if (items.length === 0) {
-      newsContent.innerHTML = '<p>No news items found.</p>';
+      console.log(`fetchAndParseFeed: [${name}] No items found.`);
+      return []; // Return empty array if no items
+    }
+
+    return items.map(item => {
+      const title = item.querySelector('title')?.textContent || 'No title';
+      const link = item.querySelector('link')?.getAttribute('href') || item.querySelector('link')?.textContent || '#'; // Atom feeds use <link href="...">
+      
+      let pubDateStr = item.querySelector('pubDate, published')?.textContent; // 'published' for Atom
+      let pubDate = new Date(); // Default to now if no date
+      if (pubDateStr) {
+          try {
+            pubDate = new Date(pubDateStr);
+            if (isNaN(pubDate.getTime())) { // Check if date is valid
+                console.warn(`fetchAndParseFeed: [${name}] Invalid date format for item "${title}": ${pubDateStr}. Using current date.`);
+                pubDate = new Date(); // Fallback to current date
+            }
+          } catch (e) {
+            console.warn(`fetchAndParseFeed: [${name}] Error parsing date for item "${title}": ${pubDateStr}. Error: ${e}. Using current date.`);
+            pubDate = new Date(); // Fallback
+          }
+      } else {
+          console.warn(`fetchAndParseFeed: [${name}] No publication date for item "${title}". Using current date.`);
+      }
+
+      let description = item.querySelector('description, summary, content')?.textContent || 'No description available.'; // 'summary' or 'content' for Atom
+      // Basic HTML removal from description
+      const tempDiv = document.createElement('div');
+      tempDiv.innerHTML = description;
+      description = (tempDiv.textContent || tempDiv.innerText || "").trim();
+      if (description.length > 200) { // Truncate long descriptions
+        description = description.substring(0, 200) + "...";
+      }
+      
+      return {
+        title,
+        link,
+        pubDate, // This is now a Date object
+        description,
+        sourceName: name,
+      };
+    });
+
+  } catch (error) {
+    console.error(`fetchAndParseFeed: [${name}] Main error caught:`, error);
+    // Optionally add a small note to UI here if needed, or handle globally
+    return []; // Return empty array on error to not break Promise.all
+  } finally {
+    console.log(`fetchAndParseFeed: [${name}] Completed.`);
+  }
+}
+
+async function displayAggregatedNews() {
+  const newsContent = document.getElementById('news-content');
+  newsContent.innerHTML = '<p>Loading all news feeds...</p>';
+  console.log('displayAggregatedNews: Started');
+
+  let allNewsItems = [];
+  const fetchPromises = newsSources.map(source => fetchAndParseFeed(source));
+
+  try {
+    const results = await Promise.all(fetchPromises);
+    results.forEach(items => {
+      if (items && items.length > 0) {
+        allNewsItems.push(...items);
+      }
+    });
+
+    console.log(`displayAggregatedNews: Total items fetched from all sources: ${allNewsItems.length}`);
+
+    if (allNewsItems.length === 0) {
+      newsContent.innerHTML = '<p>Could not load news from any source. Please check your internet connection or try again later.</p>';
+      console.log('displayAggregatedNews: No items found from any source.');
       return;
     }
 
-    items.forEach(item => {
-      const title = item.querySelector('title')?.textContent || 'No title';
-      const link = item.querySelector('link')?.textContent || '#';
-      const pubDate = item.querySelector('pubDate')?.textContent ? new Date(item.querySelector('pubDate').textContent).toLocaleDateString() : 'No date';
-      const description = item.querySelector('description')?.textContent || 'No description';
+    // Sort by publication date, most recent first
+    allNewsItems.sort((a, b) => b.pubDate - a.pubDate);
 
+    // Limit the number of displayed items
+    const itemsToDisplay = allNewsItems.slice(0, MAX_DISPLAY_ITEMS);
+
+    newsContent.innerHTML = ''; // Clear "Loading..." message
+    console.log(`displayAggregatedNews: Displaying ${itemsToDisplay.length} news items...`);
+
+    itemsToDisplay.forEach((item, index) => {
       const article = document.createElement('article');
       article.classList.add('news-item');
 
       const h3 = document.createElement('h3');
       const a = document.createElement('a');
-      a.href = link;
+      a.href = item.link;
       a.target = '_blank';
-      a.textContent = title;
+      a.textContent = item.title;
       h3.appendChild(a);
 
       const pDate = document.createElement('p');
       pDate.classList.add('publication-date');
-      pDate.textContent = pubDate;
+      pDate.textContent = item.pubDate.toLocaleDateString();
 
+      const pSource = document.createElement('p');
+      pSource.classList.add('news-source');
+      pSource.textContent = `Source: ${item.sourceName}`;
+      
       const pDesc = document.createElement('p');
       pDesc.classList.add('description');
-      // Basic HTML removal from description
-      const tempDiv = document.createElement('div');
-      tempDiv.innerHTML = description;
-      pDesc.textContent = tempDiv.textContent || tempDiv.innerText || "";
-
+      pDesc.textContent = item.description;
 
       article.appendChild(h3);
       article.appendChild(pDate);
+      article.appendChild(pSource);
       article.appendChild(pDesc);
 
       newsContent.appendChild(article);
+      // console.log(`displayAggregatedNews: Displayed item ${index + 1}: ${item.title} from ${item.sourceName}`);
     });
+    console.log('displayAggregatedNews: Finished displaying news items.');
 
   } catch (error) {
-    console.error('Error fetching or parsing news:', error);
-    newsContent.innerHTML = `<p>Sorry, we couldn't fetch the news. Error: ${error.message}</p>`;
+    // This catch block is for errors in Promise.all or subsequent processing,
+    // individual feed errors are handled within fetchAndParseFeed.
+    console.error('displayAggregatedNews: Error in processing news feeds:', error);
+    newsContent.innerHTML = `<p>Sorry, there was an error processing the news feeds. Please try again later.</p>`;
+  } finally {
+    console.log('displayAggregatedNews: Completed.');
   }
 }
 
-window.onload = fetchNews;
+window.onload = displayAggregatedNews;

--- a/style.css
+++ b/style.css
@@ -104,6 +104,13 @@ p.publication-date {
   margin-top: 0.3em; /* Added top margin for spacing from title */
 }
 
+.news-item p.news-source {
+  font-size: 0.75em;
+  font-style: italic;
+  color: #BBBBBB; /* Lighter than main text, but readable */
+  margin-bottom: 0.5em;
+}
+
 p.description {
   color: #F0F0F0; /* Main text color */
   font-size: 0.95em; /* Slightly smaller for balance */


### PR DESCRIPTION
This commit addresses issues with news fetching and expands the sources to include TechCrunch and Hacker News.

Key changes:
- Enhanced error handling and logging in `app.js` for fetching and parsing RSS feeds.
- Refactored `app.js` to fetch news concurrently from multiple sources:
  - MarkTechPost
  - TechCrunch (AI-specific and general feeds)
  - Hacker News (AI-search and frontpage feeds)
- Implemented support for parsing both RSS (`<item>`) and Atom (`<entry>`) feed formats.
- Standardized date parsing and sorts aggregated news items by publication date.
- Added source attribution for each news item in the UI and styled it.
- Updated `README.md` to reflect the new features, sources, and improved functionality.